### PR TITLE
fix: make error messages selectable and copyable (#14)

### DIFF
--- a/odm/odm.ui.views/dialogs/Upgrade.xaml
+++ b/odm/odm.ui.views/dialogs/Upgrade.xaml
@@ -17,7 +17,9 @@
     SnapsToDevicePixels="true">
 
     <DockPanel Margin="3">
-        <TextBlock Text="{Binding Message}" HorizontalAlignment="Left" DockPanel.Dock="Top"/>
+        <TextBox Text="{Binding Message}" HorizontalAlignment="Left" DockPanel.Dock="Top"
+                 IsReadOnly="True" TextWrapping="Wrap" Background="Transparent" BorderThickness="0"
+                 IsTabStop="False" Cursor="IBeam"/>
         <Button HorizontalAlignment="Right" Content="{Binding ButtonName}" DockPanel.Dock="Bottom" Click="Button_Click"/>
         <ProgressBar Visibility="{Binding IsProgressVisible}" Height="16" IsIndeterminate="True" Margin="0,10,0,10"/>
     </DockPanel>

--- a/odm/odm.ui.views/views/DeviceView.xaml
+++ b/odm/odm.ui.views/views/DeviceView.xaml
@@ -112,7 +112,9 @@
 						<my:DeviceChannelControl HorizontalAlignment="Stretch" Title="{Binding Name}">
                             <Grid>
                                 <DockPanel Margin="6" Visibility="{Binding StateError}" HorizontalAlignment="Stretch"  VerticalAlignment="Top">
-                                    <TextBlock Text="{Binding ErrorMessage}" TextWrapping="Wrap" DockPanel.Dock="Top"/>
+                                    <TextBox Text="{Binding ErrorMessage}" TextWrapping="Wrap" DockPanel.Dock="Top"
+                                             IsReadOnly="True" Background="Transparent" BorderThickness="0"
+                                             IsTabStop="False" Cursor="IBeam"/>
                                 </DockPanel>
                                 <DockPanel Margin="6" Visibility="{Binding StateLoading}" HorizontalAlignment="Left" VerticalAlignment="Top">
                                     <Label Content="{Binding AppStrings.loading}" DockPanel.Dock="Top"/>
@@ -162,7 +164,9 @@
 					</StackPanel>
 					<StackPanel Margin="3" Visibility="{Binding ChannelsErrorVisibility}" DockPanel.Dock="Top" Orientation="Vertical">
 						<TextBlock FontWeight="Bold" Foreground="Black" FontSize="10" Text="Info:"/>
-						<TextBlock Margin="0,3,0,0" TextWrapping="Wrap" MaxWidth="300" Text="{Binding ChannelLoadingErrorMessage}"/>
+						<TextBox Margin="0,3,0,0" TextWrapping="Wrap" MaxWidth="300" Text="{Binding ChannelLoadingErrorMessage}"
+                                 IsReadOnly="True" Background="Transparent" BorderThickness="0"
+                                 IsTabStop="False" Cursor="IBeam"/>
 					</StackPanel>
 					<ListBox 
 						HorizontalAlignment="Stretch" 

--- a/odm/odm.ui.views/views/ErrorView.xaml
+++ b/odm/odm.ui.views/views/ErrorView.xaml
@@ -24,19 +24,23 @@
 			Source="/odm.ui.views;component/images/alert3-th.png" 
 			Width="42" Stretch="Uniform"
 			Margin="0" VerticalAlignment="Top"/>
-		<TextBlock 
-			Grid.Row="0" Grid.Column="2" 
+		<TextBox
+			Grid.Row="0" Grid.Column="2"
 			x:Name="message"
-			Text="some message" 
+			Text="some message"
 			Margin="0" Padding="0"
-			TextWrapping="Wrap" VerticalAlignment="Center"/>
-		
-		<TextBlock 
-            Name="valueDetails" 
-            Visibility="Collapsed" 
-            Grid.Row="1" 
+			TextWrapping="Wrap" VerticalAlignment="Center"
+			IsReadOnly="True" Background="Transparent" BorderThickness="0"
+			IsTabStop="False" Cursor="IBeam"/>
+
+		<TextBox
+            Name="valueDetails"
+            Visibility="Collapsed"
+            Grid.Row="1"
             Grid.Column="2"
             TextWrapping="Wrap"
+            IsReadOnly="True" Background="Transparent" BorderThickness="0"
+            IsTabStop="False" Cursor="IBeam"
             />
 		
 		<StackPanel 

--- a/odm/odm.ui.views/views/SectionDevice/DeviceEventsView.xaml
+++ b/odm/odm.ui.views/views/SectionDevice/DeviceEventsView.xaml
@@ -41,7 +41,9 @@
 			<Border Visibility="{Binding ErrorVisibility}" DockPanel.Dock="Top" BorderBrush="Gray" Margin="3" BorderThickness="1" CornerRadius="4">
                 <StackPanel Orientation="Vertical">
                     <TextBlock Margin="3" Text="Error during events subscription:" FontWeight="Bold" Foreground="Red"/>
-                    <TextBlock Margin="3" Text="{Binding ErrorMsg}" Name="errorText" TextWrapping="Wrap"/>
+                    <TextBox Margin="3" Text="{Binding ErrorMsg}" Name="errorText" TextWrapping="Wrap"
+                             IsReadOnly="True" Background="Transparent" BorderThickness="0"
+                             IsTabStop="False" Cursor="IBeam"/>
                 </StackPanel>
             </Border>
             <Border Visibility="{Binding EventsVisibility}" BorderBrush="Gray" Margin="3" BorderThickness="1" CornerRadius="4">

--- a/odm/odm.ui.views/views/SectionDevice/SystemLogView.xaml
+++ b/odm/odm.ui.views/views/SectionDevice/SystemLogView.xaml
@@ -33,12 +33,14 @@
                     Source="/odm.ui.views;component/images/alert3-th.png" 
                     Width="42" Stretch="Uniform"
                     Margin="0" VerticalAlignment="Top"/>
-                <TextBlock 
-                    Grid.Row="0" Grid.Column="2" 
+                <TextBox
+                    Grid.Row="0" Grid.Column="2"
                     x:Name="message"
-                    Text="{Binding ErrorMessage}" 
+                    Text="{Binding ErrorMessage}"
                     Margin="0" Padding="0"
-                    TextWrapping="Wrap" VerticalAlignment="Center"/>
+                    TextWrapping="Wrap" VerticalAlignment="Center"
+                    IsReadOnly="True" Background="Transparent" BorderThickness="0"
+                    IsTabStop="False" Cursor="IBeam"/>
                 <!--<Expander Header="Details" Visibility="Visible">
 			<WebBrowser/>
 		</Expander>-->

--- a/odm/odm.ui.views/views/SectionDevice/TimeSettingsView.xaml
+++ b/odm/odm.ui.views/views/SectionDevice/TimeSettingsView.xaml
@@ -37,12 +37,14 @@
 					Source="/odm.ui.views;component/images/alert3-th.png" 
 					Width="42" Stretch="Uniform"
 					Margin="0" VerticalAlignment="Top"/>
-				<TextBlock 
+				<TextBox
 					x:Name="ErrorMessage"
-					Grid.Row="0" Grid.Column="2" 
-					Text="some message" 
+					Grid.Row="0" Grid.Column="2"
+					Text="some message"
 					Margin="0" Padding="0"
-					TextWrapping="Wrap" VerticalAlignment="Center"/>
+					TextWrapping="Wrap" VerticalAlignment="Center"
+					IsReadOnly="True" Background="Transparent" BorderThickness="0"
+					IsTabStop="False" Cursor="IBeam"/>
 			</Grid>
 			<StackPanel Orientation="Horizontal" Margin="0">
 				<TextBlock 

--- a/odm/odm.ui.views/views/SectionNVT/PtzView.xaml
+++ b/odm/odm.ui.views/views/SectionNVT/PtzView.xaml
@@ -818,9 +818,11 @@
 		</Grid>
 
 		<Border CornerRadius="4" Background="Black" Style="{StaticResource ErrorMessageStyle}" HorizontalAlignment="Center" VerticalAlignment="Center" BorderThickness="2" BorderBrush="Red">
-			<TextBlock Name="captionErrorMessage"
-                       Margin="3" Foreground="Red"
-                       FontSize="18" FontWeight="Bold" Background="Black"/>
+			<TextBox Name="captionErrorMessage"
+                     Margin="3" Foreground="Red"
+                     FontSize="18" FontWeight="Bold" Background="Black"
+                     IsReadOnly="True" TextWrapping="Wrap" BorderThickness="0"
+                     IsTabStop="False" Cursor="IBeam"/>
 		</Border>
 
 	</Grid>

--- a/odm/odm.ui.views/views/SectionNVT/PtzView.xaml.cs
+++ b/odm/odm.ui.views/views/SectionNVT/PtzView.xaml.cs
@@ -213,7 +213,7 @@ namespace odm.ui.activities {
 			//valuePresetsList.CreateBinding(ListBox.SelectedItemProperty, this, x => x.SelectedPreset, (m, v) => m.SelectedPreset = v);
 			//ReloadPresets();
 
-			captionErrorMessage.CreateBinding(TextBlock.TextProperty, this, x => x.ErrorMessage);
+			captionErrorMessage.CreateBinding(TextBox.TextProperty, this, x => x.ErrorMessage);
 
 			// setup controls for absolute movements
 

--- a/odm/odm.ui.views/views/SectionNVT/VideoSourcesView.xaml
+++ b/odm/odm.ui.views/views/SectionNVT/VideoSourcesView.xaml
@@ -43,7 +43,9 @@
                         <my:DeviceChannelControl HorizontalAlignment="Stretch" Title="{Binding Name}">
                             <Grid>
                                 <DockPanel Margin="6" Visibility="{Binding StateError}" HorizontalAlignment="Stretch"  VerticalAlignment="Top">
-                                    <TextBlock Text="{Binding ErrorMessage}" TextWrapping="Wrap" DockPanel.Dock="Top"/>
+                                    <TextBox Text="{Binding ErrorMessage}" TextWrapping="Wrap" DockPanel.Dock="Top"
+                                             IsReadOnly="True" Background="Transparent" BorderThickness="0"
+                                             IsTabStop="False" Cursor="IBeam"/>
                                 </DockPanel>
                                 <DockPanel Margin="6" Visibility="{Binding StateLoading}" HorizontalAlignment="Left" VerticalAlignment="Top">
                                     <Label Content="{Binding AppStrings.loading}" DockPanel.Dock="Top"/>


### PR DESCRIPTION
Fixes #14. Replaces non-selectable TextBlock controls used for error display with IsReadOnly TextBox controls. Visually identical but supports text selection and Ctrl+C.

## Summary

- Replaced `TextBlock` with `TextBox` (IsReadOnly=True, Background=Transparent, BorderThickness=0, IsTabStop=False, Cursor=IBeam) in all error/exception display locations
- Also updated the PtzView.xaml.cs binding from `TextBlock.TextProperty` to `TextBox.TextProperty` for the `captionErrorMessage` element
- Build confirmed clean (0 errors)

## Files changed

| File | Element |
|------|---------|
| `ErrorView.xaml` | `message`, `valueDetails` TextBlocks |
| `dialogs/Upgrade.xaml` | `{Binding Message}` TextBlock |
| `DeviceView.xaml` | `{Binding ErrorMessage}`, `{Binding ChannelLoadingErrorMessage}` TextBlocks |
| `SectionDevice/DeviceEventsView.xaml` | `{Binding ErrorMsg}` TextBlock |
| `SectionNVT/VideoSourcesView.xaml` | `{Binding ErrorMessage}` TextBlock |
| `SectionNVT/PtzView.xaml` + `.cs` | `captionErrorMessage` TextBlock + binding property fix |
| `SectionDevice/SystemLogView.xaml` | `{Binding ErrorMessage}` TextBlock |
| `SectionDevice/TimeSettingsView.xaml` | `ErrorMessage` TextBlock |

🤖 Generated with [Claude Code](https://claude.com/claude-code)