### PR TITLE
docs: Sprint 4 architecture and feature documentation harvest

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,144 @@
+# ODM Architecture
+
+## Solution Structure
+
+ODM is a C#/.NET 4.8 WPF application backed by a multi-language codebase:
+
+| Layer | Language | Projects |
+|-------|----------|----------|
+| ONVIF session | F# | `onvif/onvif.session` |
+| ONVIF types/services | C# (hand-maintained + WCF-generated) | `onvif/onvif.services` |
+| UI activities (view models) | F# | `odm/odm.ui.activities` |
+| UI views / controls | C# + XAML | `odm/odm.ui.views` |
+| WPF app entry point | C# | `odm/odm.ui.app` |
+| Native video pipeline | C++ | `odm/odm.player/odm.player.lib` |
+| Player host (C++/CLI bridge) | C++/CLI | `odm/odm.player/odm.player.host` |
+| Player .NET API | C++/CLI | `odm/odm.player/odm.player.net` |
+| Unit/integration tests | C# (MSTest) | `odm/odm.tests` |
+
+---
+
+## Video Pipeline
+
+Video playback is a multi-process pipeline:
+
+```
+NvtSession.fs (F#)
+  └── GetStreamUri() → RTSP URI
+       ↓
+VideoPlayerActivity.fs (F#)
+  └── passes URI to player view
+       ↓
+LiveVideoView.xaml.cs (C#)
+  └── calls odm.player.net.dll (C++/CLI)
+       ↓
+odm.player.host.exe (C++/CLI, separate process)
+  ├── Live555 → RTSP/RTP receive + SDP codec dispatch
+  ├── H264VirtualSink / H265VirtualSink → Annex-B NAL framing
+  ├── FFmpeg avcodec → decode (H.264, H.265, MJPEG, MPEG4)
+  └── VideoRenderer → YUV→RGB → shared VideoBuffer
+       ↓
+VideoPlayer.xaml.cs (C#)
+  └── WriteableBitmap rendering from VideoBuffer
+```
+
+### Codec dispatch in `Live555.cpp` — `InitSubsession()`
+
+The SDP codec name maps to an FFmpeg `AV_CODEC_ID`:
+
+| SDP codec name | FFmpeg codec ID |
+|---|---|
+| `H264` | `AV_CODEC_ID_H264` |
+| `H265` | `AV_CODEC_ID_HEVC` |
+| `JPEG`, `MJPEG` | `AV_CODEC_ID_MJPEG` |
+| `MP4V-ES`, `MPEG4` | `AV_CODEC_ID_MPEG4` |
+| `MPV` | `AV_CODEC_ID_MPEG2VIDEO` |
+
+Unknown codec names return `nullptr` from `InitSubsession()` — the subsession is silently skipped.
+
+### NAL framing sinks
+
+H.264 and H.265 RTP payloads arrive as raw NAL units. Both require Annex-B start code prepending (`0x00 0x00 0x00 0x01`) before the FFmpeg decoder. `H264VirtualSink` and `H265VirtualSink` perform this framing identically.
+
+---
+
+## Transport Layer (`onvif/onvif.session/`)
+
+### `NvtSession.fs` — session routing
+
+`NvtSessionFactory` is the entry point for all ONVIF communication. It accepts a `NetworkCredential` and a device `Uri` and creates WCF channel factories.
+
+**HTTPS detection:** `CreateSession(deviceUri)` checks `Uri.UriSchemeHttps` and sets `useTls=true`, which selects `SslStreamTransportBindingElement` instead of `HttpTransportBindingElement` when building channel factories.
+
+**Scheme-upgrade fallback:** `CreateSession(uris:Uri[])` (the multi-URI overload used after WS-Discovery) probes each URI with a SOAP `GetSystemDateAndTime` call. If all original HTTP URIs fail, `GenerateHttpsVariants` produces HTTPS alternatives (port 443, then 8443) and retries. See `docs/features/https-tls.md` for details.
+
+**`factory_wrapper`:** Memoizes separate HTTP and HTTPS factory instances. The same `NvtSessionFactory` instance can serve channels over both schemes without re-allocating factories.
+
+### `SslStreamTransport.fs` — custom TLS transport
+
+Replaces `HttpsTransportBindingElement` for all HTTPS connections. Sends the full HTTP request (headers + body) in a single `SslStream.Write` call, working around gSOAP 2.8's multi-record TLS fragmentation crash.
+
+Key helpers in `SslStreamHelpers` module:
+- `decodeChunked` — handles `Transfer-Encoding: chunked` responses
+- `parseResponse` — splits HTTP response into status, headers, body
+- `stripDoctype` — removes XML DOCTYPE declarations before WCF message parsing
+
+### `FixUrl` — host/port fixup
+
+`FixUrl` (NvtSession.fs) corrects RTSP stream URIs where the camera's self-reported host/port does not match the network address used to connect. It handles:
+- `rtsp://` — standard fixup
+- `rtsps://` — scheme preserved, host/port fixed
+- `http://` on HTTPS device — upgraded to `https://` with port correction
+
+---
+
+## ONVIF Type System (`onvif/onvif.services/`)
+
+### Type maintenance model
+
+`onvif.types.cs` is **hand-maintained** (not auto-generated from WSDL). It defines the C# data contracts used for ONVIF SOAP deserialization. Adding support for a new ONVIF feature requires:
+
+1. Adding the new type/enum to `onvif.types.cs`
+2. Adding the corresponding XSD to `schemas/onvif.xsd`
+3. Mirroring the XSD change to `Service References/services/onvif.xsd` (both copies must stay in sync)
+
+The WCF service proxies (`Reference.cs`, `Reference1.cs`) are auto-generated from WSDL via svcutil and are not manually edited.
+
+### VideoEncoding enum
+
+```csharp
+public enum VideoEncoding {
+    jpeg, mpeg4, h264, h265
+}
+```
+
+Deserialization fails at runtime if a camera returns an encoding value not present in this enum. Every new codec added to the ONVIF spec requires an enum member here.
+
+---
+
+## Credential Flow
+
+Credentials are managed outside the F# session layer. `DeviceListViewModel.cs` (C#) owns credential iteration:
+
+1. Checks the per-device credential cache (keyed by host IP)
+2. On cache miss or failure, iterates all stored credentials via `AccountManager`
+3. Falls back to anonymous session as a last resort
+
+The F# `NvtSessionFactory` accepts one `NetworkCredential` at construction time and is stateless with respect to credential rotation. See `docs/credentials.md` for full details.
+
+---
+
+## Test Architecture
+
+### Unit/integration tests (`odm/odm.tests/`)
+
+MSTest project targeting .NET 4.8. Tests are split by category:
+
+- **Offline** (`[TestCategory("Offline")]` or untagged) — run in CI, no camera required
+- **Integration** (`[TestCategory("Integration")]`) — skipped in CI via `Assert.Inconclusive` when `ODM_TEST_HOST` env var is absent; run manually against a real camera
+
+The test project references `onvif.session.dll` and its dependencies from the Release output directory.
+
+### E2E UI tests (planned — `odm/odm.e2e-tests/`)
+
+FlaUI-based (UIA3) end-to-end test suite that drives the full ODM UI against real cameras and uses Claude vision API for screenshot analysis. See `docs/e2e-smoke-test-poc.md` for architecture details.

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,0 +1,121 @@
+# CI Workflow
+
+Workflow file: `.github/workflows/odm.yml`
+
+Triggers: push and pull request to `development` branch.  
+Runner: `windows-2022`.
+
+---
+
+## Build Order
+
+Steps run in this sequence — order matters because later steps depend on earlier outputs:
+
+| Step | What it does |
+|------|-------------|
+| Checkout | Full history (`fetch-depth: 0`) — needed for `git rev-parse --short HEAD` in version patching |
+| Setup VS Dev Environment | Installs Visual Studio 2022 build tools via `seanmiddleditch/gha-setup-vsdevenv@v4` |
+| Install .NET Framework targeting packs | Copies .NET 4.0 and 4.5 reference assemblies via NuGet — required because `windows-2022` runners don't include them |
+| Set build version | Patches all AssemblyInfo files and the vdproj — see below |
+| Build application | `msbuild odm.sln /p:Configuration=Release /p:Platform=x64 /m` — full solution, parallel |
+| Restore tests | `dotnet restore odm/odm.tests/odm.tests.csproj` |
+| Build tests | `msbuild odm.tests.csproj /p:Configuration=Debug /p:Platform="Any CPU"` |
+| Run tests | `vstest.console.exe` — runs offline tests only; integration tests skip via `Assert.Inconclusive` |
+| Collect artifacts | `package.bat` — stages `build/` directory |
+| Verify required DLLs | PowerShell check that all required binaries are present in `build/` |
+| Upload zip artifact | `actions/upload-artifact@v4` — uploads `build/` as `odm-build-zip` |
+| Strip PDB files | Removes `*.pdb` from MSI source dirs (not from zip) |
+| DisableOutOfProcBuild | Runs `DisableOutOfProcBuild.exe` — required for vdproj builds |
+| Build installer | `devenv odm.sln /Build "Release|x64" /Project odm.setup` |
+| Upload installer | `actions/upload-artifact@v4` — uploads MSI as `odm-installer` |
+
+---
+
+## Version Patching
+
+The "Set build version" step is the single source of truth for all version numbers in a given CI build. No version commits are made to source control by CI.
+
+**Variables computed:**
+
+```
+$run     = github.run_number          (e.g. 42)
+$hash    = git rev-parse --short HEAD  (e.g. b7ee223)
+$ver4    = "3.0.$run.0"               (e.g. 3.0.42.0)
+$verMsi  = "3.0.$run"                  (e.g. 3.0.42)
+$verInfo = "3.0.$run+$hash"           (e.g. 3.0.42+b7ee223)
+```
+
+**Files patched (regex replacement, in-memory, then written):**
+
+- `odm/~cfg/AssemblyInfo.global.cs`, `onvif/~cfg/AssemblyInfo.global.cs`, `utils/~cfg/AssemblyInfo.global.cs`
+  - `AssemblyVersion` → `$ver4`
+  - `AssemblyFileVersion` → `$ver4`
+  - `AssemblyInformationalVersion` → `$verInfo`
+
+- `odm/~cfg/AssemblyInfo.global.fs`, `onvif/~cfg/AssemblyInfo.global.fs`, `utils/~cfg/AssemblyInfo.global.fs`
+  - `AssemblyVersion` → `$ver4`
+  - `AssemblyFileVersion` → `$ver4`
+
+- `odm.setup/odm.setup.vdproj`
+  - `ProductVersion` → `$verMsi`
+  - `ProductCode` → fresh `[guid]::NewGuid()` (rotated per build)
+
+---
+
+## Artifact Structure
+
+### `odm-build-zip` (zip of `build/`)
+
+All runtime files including PDBs. Intended for local test deploys and debugging.
+
+Required files (verified by CI, build fails if missing):
+- `build/odm.exe`
+- `build/odm.player.net.dll`
+- `build/odm.player.host.exe`
+- `build/odm.player.media.dll`
+- `build/avcodec-61.dll`
+- `build/avformat-61.dll`
+- `build/avutil-59.dll`
+- `build/swscale-8.dll`
+- `build/swresample-5.dll`
+
+### `odm-installer` (`odm.setup/Release/odm.setup.msi`)
+
+PDB-stripped MSI. Triggers a major upgrade on any machine with a prior ODM install (`2.x` or any earlier `3.0.x` build).
+
+---
+
+## Why the Installer Is Built Separately
+
+Visual Studio Deployment Projects (`.vdproj`) cannot be built by MSBuild in out-of-process mode. Attempting `msbuild /Project odm.setup` without `DisableOutOfProcBuild` either fails or produces a zero-byte MSI silently.
+
+The workflow works around this by:
+1. Building all other projects with parallel MSBuild (`/m`)
+2. Calling `DisableOutOfProcBuild.exe` (ships with Visual Studio)
+3. Building the installer with `devenv /Build /Project odm.setup` (in-process)
+
+Building the full solution in step 1 (rather than just `odm.ui.app`) ensures native C++/CLI projects (`live555.vcxproj`, `odm.player.lib.vcxproj`, `odm.player.net.vcxproj`) are always compiled — this was the root cause of issue #1 where selective project builds could silently skip them.
+
+---
+
+## .NET Framework Reference Assemblies
+
+`windows-2022` GitHub Actions runners include .NET 4.6+ reference assemblies but not 4.0 or 4.5. The workflow installs them via NuGet:
+
+```
+Microsoft.NETFramework.ReferenceAssemblies.net40
+Microsoft.NETFramework.ReferenceAssemblies.net45
+```
+
+Copies are installed to the standard reference assembly path (`C:\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.0` etc.) so MSBuild resolves them transparently.
+
+---
+
+## Closed Issues
+
+| Issue | What was fixed |
+|-------|---------------|
+| #1 | Full solution build ensures native player projects are never skipped |
+| #12 | Unified CI versioning — all AssemblyInfo + vdproj patched in one step |
+| #13 | Per-CI-build ProductCode GUID rotation enables clean major upgrades |
+| #15 | `build/` as single staging area for both zip and MSI inputs |

--- a/docs/features/h265-hevc.md
+++ b/docs/features/h265-hevc.md
@@ -1,0 +1,118 @@
+# H.265/HEVC Support
+
+Delivered in Sprint 4 (squash-merged as commit `b7ee223`).
+
+---
+
+## What Was Built
+
+End-to-end H.265/HEVC video stream playback in ODM, covering all five layers of the video pipeline:
+
+1. ONVIF schema and C# type bindings
+2. Live555 H.265 RTP depayloader
+3. FFmpeg HEVC decoder
+4. C++ player pipeline (codec dispatch + NAL framing)
+5. F# UI activity (encoder settings)
+
+---
+
+## Five Blocking Gaps Fixed
+
+| Gap | Layer | Problem | Fix |
+|-----|-------|---------|-----|
+| 1 | FFmpeg | avcodec-54 (2012) has no HEVC decoder — `AV_CODEC_ID_HEVC` did not exist | Upgraded to FFmpeg n7.1-lgpl-shared (avcodec-61) |
+| 2 | live555 | 2013 build has no `H265VideoRTPSource` RTP depayloader | Upgraded live555; added `H265VirtualSink` |
+| 3 | C++ pipeline | `InitSubsession()` had no branch for `"H265"` codec name — stream silently dropped | Added H265 branch → `AV_CODEC_ID_HEVC` |
+| 4 | ONVIF types | `VideoEncoding` enum had no `h265` value; `H265Configuration`, `H265Profile`, `H265Options` types missing | Added all missing types to `onvif.types.cs` and both XSD copies |
+| 5 | F# UI | `VideoSettingsActivity.fs` match expression threw `ArgumentException` on unknown encoding | Added `h265` case to all encoder-dispatch match expressions |
+
+---
+
+## FFmpeg Upgrade
+
+**From:** ffmpeg-git-a5c1a0c (libavcodec-54, 2012)  
+**To:** FFmpeg n7.1-lgpl-shared
+
+New DLL versions checked into `build/` and staged in CI:
+
+| DLL | Version |
+|-----|---------|
+| `avcodec-61.dll` | 61 |
+| `avformat-61.dll` | 61 |
+| `avutil-59.dll` | 59 |
+| `swscale-8.dll` | 8 |
+| `swresample-5.dll` | 5 |
+
+**API migrations required:**
+- `av_register_all()` / `avcodec_register_all()` — removed in FFmpeg 4.0; calls removed
+- `CODEC_ID_*` constants renamed to `AV_CODEC_ID_*` throughout `Live555.cpp` and `VideoDecoder.hpp`
+- `avcodec_alloc_context()` → `avcodec_alloc_context3()`
+- `avcodec_open()` → `avcodec_open2()`
+- `avcodec_alloc_frame()` → `av_frame_alloc()`
+
+---
+
+## live555 H265VideoRTPSource
+
+The upgraded live555 includes `H265VideoRTPSource` (added to live555 circa 2014). live555 automatically creates the correct `RTPSource` subclass based on the SDP codec name — no application code changes are required for RTP depayloading once the library is updated.
+
+---
+
+## H265VirtualSink (NAL framing)
+
+**File:** `odm/odm.player/odm.player.lib/include/odm.player.lib/H265VirtualSink.hpp`
+
+H.265 RTP payloads arrive as raw NAL units without Annex-B start codes. FFmpeg's HEVC decoder expects Annex-B format (`0x00 0x00 0x00 0x01` prefix). `H265VirtualSink` prepends the 4-byte start code before each NAL unit — identical logic to `H264VirtualSink`.
+
+`SetupSubsession()` in `Live555.cpp` selects:
+- `H264VirtualSink` for H.264 streams
+- `H265VirtualSink` for H.265 streams
+- `VirtualSink` (raw passthrough) for all other codecs
+
+---
+
+## CODEC_FLAG2_CHUNKS for HEVC
+
+`VideoDecoder.hpp` sets `CODEC_FLAG2_CHUNKS` for both `AV_CODEC_ID_H264` and `AV_CODEC_ID_HEVC`. This flag tells FFmpeg to handle incomplete frames gracefully — necessary because RTP delivery may split a NAL unit across multiple packets.
+
+---
+
+## ONVIF Type Additions
+
+All additions are in `onvif/onvif.services/onvif.types.cs` and mirrored to both XSD copies (`schemas/onvif.xsd` and `Service References/services/onvif.xsd`):
+
+| Type | What it is |
+|------|-----------|
+| `VideoEncoding.h265` | New enum member (`XmlEnum("H265")`) added after `h264` |
+| `H265Profile` | Enum: `main`, `main10`, `mainStillPicture` (ONVIF 17.06+) |
+| `H265Configuration` | Class with `govLength` and `h265Profile` properties |
+| `H265Options` | Class with resolution, govLength, frameRate, encodingInterval, and H265 profile arrays |
+| `H265Options2` | Extended options including bitrateRange |
+| `VideoEncoderConfiguration.h265` | New property of type `H265Configuration` |
+| `VideoEncoderConfigurationOptions.h265` | New property of type `H265Options` |
+| `VideoEncoderOptionsExtension.h265` | New property of type `H265Options2` |
+
+These types are hand-maintained (not auto-generated from WSDL). They follow the exact same patterns as the adjacent H.264 types.
+
+---
+
+## Media2 Detection Hack (Issue #21)
+
+Some cameras advertise H.265 profiles only via the ONVIF Media2 service (`GetVideoEncoderConfigurations` on `onvif10_media2`) rather than the Media1 service. A workaround was added in `NvtSession.fs` — `GetVideoEncoderConfigurationsMedia2` — that calls the Media2 endpoint when present.
+
+Issue #21 tracks proper Media2 support as a follow-up sprint.
+
+---
+
+## F# UI Activity Changes (`VideoSettingsActivity.fs`)
+
+All codec match expressions that previously covered only `jpeg`, `mpeg4`, `h264` were extended with an `h265` case:
+
+- Frame rate range extraction from `options.h265`
+- Encoding interval range from `options.h265`
+- GOV length range from `options.h265`
+- GOV length read from `vec.h265.govLength`
+- Bitrate range from `H265Options2.bitrateRange`
+- Encoder configuration creation: builds `H265Configuration` with `govLength`
+
+Without these additions, selecting an H.265 profile in the video settings UI would throw `ArgumentException` on the default `|_` branch.

--- a/docs/features/https-tls.md
+++ b/docs/features/https-tls.md
@@ -1,0 +1,97 @@
+# HTTPS/TLS Camera Support
+
+Delivered in Sprint 4 (squash-merged as commit `2326947` and `b7ee223`).
+
+---
+
+## What Was Built
+
+ODM can now connect to cameras where HTTP is disabled and only HTTPS is available. All ONVIF operations (discovery, capabilities, profiles, PTZ, imaging, events) and live video streaming work against such cameras.
+
+Three feature areas were shipped:
+
+| Feature | Description |
+|---------|-------------|
+| **F1 — HTTPS-only camera connectivity** | Scheme-upgrade fallback when WS-Discovery returns an HTTP XAddr on a camera that only accepts HTTPS |
+| **F2 — RTSP streaming over HTTPS** | Automatic transport negotiation (plain RTSP → RTSP-over-HTTP) for HTTPS-only cameras |
+| **F3 — RTSPS detection** | Graceful error message when the camera returns an `rtsps://` stream URI |
+
+---
+
+## Key Architecture Decisions
+
+### SslStream single-write transport replaces `HttpsTransportBindingElement`
+
+**Problem:** gSOAP 2.8 (used by most IP cameras, including Milesight) crashes or stalls when the HTTP request is split across multiple TLS application-data records. .NET's `HttpWebRequest` / `HttpsTransportBindingElement` always writes headers and body as separate TLS records.
+
+**Solution:** A custom WCF `BindingElement` — `SslStreamTransportBindingElement` in `onvif/onvif.session/SslStreamTransport.fs` — opens a raw `TcpClient`, wraps it in `SslStream`, and sends the full HTTP request (headers + body) in a single `Write` call. This guarantees one TLS record per request and is compatible with all tested cameras.
+
+**Alternative rejected:** Patching `HttpsTransportBindingElement` to use `AllowWriteStreamBuffering=true` — not available in .NET 4.0 WCF binding pipeline.
+
+### WS-Addressing Action header stripping
+
+gSOAP cameras return HTTP 500 `MustUnderstand` faults when they receive `ws:Action` headers. `SslStreamTransport.fs` strips the `Action` mustUnderstand header from outgoing requests by default.
+
+**Exception:** Channels declared with `wsAddressing=true` (Events, Metadata subscriptions) require the Action header for server-side dispatch — stripping is skipped for those channels based on the message version (`Soap12WSAddressing10`).
+
+### Scheme-upgrade fallback (`NvtSession.fs` — `CreateSession(uris:Uri[])`)
+
+When WS-Discovery returns `http://` XAddrs and TCP-level connectivity or SOAP probing fails, `GenerateHttpsVariants` generates HTTPS alternatives (port 443, then 8443) and retries. The SOAP probe (`GetSystemDateAndTime` unauthenticated) is used rather than a bare TCP connect because some cameras accept TCP connections on port 80 but silently drop HTTP payloads.
+
+Fallback is sequential: all HTTP URIs are tried to completion before HTTPS variants are attempted. This avoids racing HTTPS connections against HTTP on cameras that support both.
+
+### `Expect100Continue = false`
+
+Cameras do not understand `Expect: 100-Continue` and silently stall when it is present. This flag is set on both `ServicePointManager` (global, in `App.xaml.cs` and test init) and per-`ServicePoint` inside `CreateSession`.
+
+### DOCTYPE stripping
+
+The Milesight Analytics service includes an XML `DOCTYPE` declaration in its SOAP responses. WCF's `XmlDictionaryReader` rejects DOCTYPE declarations as a security measure. `SslStreamTransport.fs` strips any DOCTYPE before passing the response to the WCF message decoder.
+
+### Certificate validation bypass
+
+`App.xaml.cs` sets `ServicePointManager.ServerCertificateValidationCallback` to return `true` unconditionally. This is intentional — ONVIF cameras use self-signed certificates and there is no PKI to validate against. This must not be removed.
+
+---
+
+## Transport Selection Per Channel Type
+
+| Channel type | `wsAddressing` | Transport used | Action header |
+|---|---|---|---|
+| Standard ONVIF services (Device, Media, PTZ, etc.) | false | `SslStreamTransportBindingElement` | Stripped |
+| Events / Metadata subscriptions | true | `SslStreamTransportBindingElement` | Preserved |
+| HTTP cameras (all channels) | false | `HttpTransportBindingElement` | Preserved (no mustUnderstand issue on HTTP) |
+
+---
+
+## RTSP Transport Negotiation (F2)
+
+For HTTPS devices, `GetStreamUri` in `NvtSession.fs` attempts:
+1. Standard RTSP (`Transport.Protocol = RTSP`)
+2. If the camera's device session is HTTPS-only: retry with `RtspOverHttp` (`Transport.Protocol = HTTP`)
+
+The retry is transparent — no modal dialogs. `FixUrl` was updated to handle `http://` stream URIs that are RTSP-over-HTTP tunnels on an HTTPS device, upgrading the stream URI scheme when appropriate.
+
+---
+
+## RTSPS Graceful Error (F3)
+
+`VideoPlayerActivity.fs` exposes `IsRtspsUri` (a static member, case-insensitive scheme check) called after `GetStreamUri` returns. If the URI scheme is `rtsps://`, a `NotSupportedException` is raised with a descriptive message. The existing `with`-handler in the activity surfaces this via `ErrorView` — the video panel shows the error instead of going blank or crashing.
+
+Live555 in this build was not compiled with OpenSSL, so native `rtsps://` playback is not supported. F3 is best-effort graceful degradation.
+
+---
+
+## Test Coverage
+
+| Test file | Type | What it covers |
+|---|---|---|
+| `HttpsBindingTests.cs` | Offline unit | `SslStreamTransportBindingElement` present when `useTls=true` |
+| `SchemeUpgradeTests.cs` | Offline unit | `GenerateHttpsVariants` logic — HTTP→HTTPS URI generation, HTTPS pass-through, deduplication |
+| `HttpsIntegrationTests.cs` | Integration (skipped in CI) | Connect, GetCapabilities, GetProfiles, GetStreamUri against 192.168.1.190 |
+| `FixUrlHttpsTests.cs` | Offline unit | `FixUrl` with HTTPS device URI + RTSP/RTSPS stream URI combinations |
+| `StreamTransportNegotiationTests.cs` | Offline unit | RTSP → RtspOverHttp fallback sequence |
+| `RtspsUriTests.cs` | Offline unit | `IsRtspsUri` detection — true/false for various schemes including uppercase |
+| `SslStreamHelpersTests.cs` | Offline unit | `decodeChunked`, `parseResponse`, `stripDoctype` helpers |
+
+Integration tests are gated by `[TestCategory("Integration")]` and skip when `ODM_TEST_HOST` is not set. CI runs only offline tests.

--- a/docs/features/installer.md
+++ b/docs/features/installer.md
@@ -1,0 +1,95 @@
+# Installer Pipeline
+
+Delivered in Sprint 4.
+
+---
+
+## Overview
+
+Each CI build produces two artifacts from the same `build/` staging area:
+
+| Artifact | Contents | PDB files |
+|---|---|---|
+| `odm-build-zip` (zip of `build/`) | `odm.exe`, all DLLs, FFmpeg DLLs, assets | Included (for debugging) |
+| `odm-installer` (`odm.setup.msi`) | Same binaries as zip | Stripped before MSI build |
+
+---
+
+## Versioning Scheme
+
+All CI builds use the `3.0.<run_number>` versioning scheme:
+
+| Field | Format | Example |
+|-------|--------|---------|
+| `AssemblyVersion` / `AssemblyFileVersion` | `3.0.<run>.0` | `3.0.42.0` |
+| `AssemblyInformationalVersion` | `3.0.<run>+<git_short_hash>` | `3.0.42+b7ee223` |
+| MSI `ProductVersion` | `3.0.<run>` | `3.0.42` |
+| MSI `ProductCode` | Fresh GUID per build | `{F3A1B2C4-...}` |
+
+**Why `3.0.x`:** All previous shipped builds used `2.x` versioning. Using `3.0.x` ensures every CI build is strictly greater than any existing installed version, so Windows Installer's major-upgrade comparison (`ProductVersion` must increase) always triggers the automatic uninstall-and-reinstall flow without requiring manual uninstall.
+
+**Why a fresh ProductCode per build:** Windows Installer uses `ProductCode` as the primary identity for upgrade detection. Rotating it on every build ensures that every new CI build is treated as a different product for upgrade purposes, enabling clean major upgrades even when the version number changes are small.
+
+---
+
+## Version Patching (Single Source of Truth)
+
+The CI workflow (`odm.yml` — "Set build version" step) patches all version strings in one PowerShell step before the build runs:
+
+**C# AssemblyInfo files patched:**
+- `odm/~cfg/AssemblyInfo.global.cs`
+- `onvif/~cfg/AssemblyInfo.global.cs`
+- `utils/~cfg/AssemblyInfo.global.cs`
+
+**F# AssemblyInfo files patched:**
+- `odm/~cfg/AssemblyInfo.global.fs`
+- `onvif/~cfg/AssemblyInfo.global.fs`
+- `utils/~cfg/AssemblyInfo.global.fs`
+
+**Installer patched:**
+- `odm.setup/odm.setup.vdproj` — `ProductVersion` and `ProductCode` fields
+
+This single step replaced the previous pattern of committing version bumps to source, which caused noise in the git history and created race conditions in CI.
+
+---
+
+## `build/` Staging Area
+
+`package.bat` (run as the "Collect artifacts" CI step) copies all output from `odm/odm.ui.app/bin/x64/Release/` into `build/`. The `build/` directory serves as both:
+- The runtime directory for local test deploys (the `ODM-dev` scheduled task runs `build/odm.exe`)
+- The source for the zip artifact upload
+
+**Required artifacts verified by CI** (will fail the build if missing):
+
+```
+build/odm.exe
+build/odm.player.net.dll
+build/odm.player.host.exe
+build/odm.player.media.dll
+build/avcodec-61.dll
+build/avformat-61.dll
+build/avutil-59.dll
+build/swscale-8.dll
+build/swresample-5.dll
+```
+
+---
+
+## PDB Stripping
+
+PDBs are stripped from the installer inputs but kept in the zip artifact. The "Strip PDB files" CI step removes `*.pdb` from:
+- `odm/odm.ui.app/bin/x64/Release/` (MSI source directory)
+- `build/` (already-packaged artifacts)
+
+This runs after the zip artifact upload and before the MSI build, so the zip retains PDBs for post-deploy debugging while the MSI shipped to end users does not embed them.
+
+---
+
+## MSI Build Constraints
+
+The Visual Studio Deployment Project (`odm.setup.vdproj`) requires in-process MSBuild — it cannot be built with `/m` parallel builds and will silently produce an empty MSI if attempted. The CI workflow handles this by:
+
+1. Building the full solution with parallel MSBuild: `msbuild odm.sln /m`
+2. Building the installer separately with `devenv /Build /Project odm.setup` (which sets `DisableOutOfProcBuild` first)
+
+This separation was the fix for issue #1 — previously, using `/Project odm.ui.app` could silently skip the native C++/CLI player projects (`live555`, `odm.player.lib`, `odm.player.net`), leaving stale or absent `odm.player.net.dll` in the output.


### PR DESCRIPTION
## Summary

- Extracts durable long-term knowledge from Sprint 4 (HTTPS/TLS, H265/HEVC, installer fixes) into `docs/`
- No code changes — documentation only

## Docs added

| File | Contents |
|------|----------|
| `docs/architecture.md` | Solution structure, video pipeline, transport layer design, ONVIF type model, test architecture |
| `docs/features/https-tls.md` | SslStream design, scheme-upgrade algorithm, cert bypass rationale, test coverage matrix |
| `docs/features/h265-hevc.md` | Five blocking gaps and fixes, FFmpeg n7.1 migration, NAL framing, Media2 detection hack, issue #21 callout |
| `docs/features/installer.md` | 3.0.x versioning rationale, ProductCode rotation, build\ staging area, PDB stripping strategy |
| `docs/ci.md` | Build order with rationale, version patching, artifact structure, devenv vs msbuild split |
| `docs/development-guide.md` | Build commands, test execution, key directories, branching, testing conventions |
| `docs/sprint-history.md` | Sprint 1–4 deliverables and known limitations |

## Review

Reviewed and APPROVED by 🟪 odm-rev on branch `docs/sprint4-harvest` @ `ce76a28`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)