### PR TITLE
feat: spec-compliant ONVIF session init with eager endpoint resolution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,29 @@
+# Build outputs
+**/bin/
+**/obj/
+build/
+build_output.txt
+
+# Visual Studio
+*.user
+*.suo
+.vs/
+*.cache
+*.ncb
+*.sdf
+*.opensdf
+*_i.c
+*_p.c
+*.ilk
+*.meta
+*.pdb
+*.iobj
+*.ipdb
+
+# Claude Code / fleet
+.claude/
+permissions.json
+
+# Lib docs
+libs/*/doc/
+

--- a/docs/principles.md
+++ b/docs/principles.md
@@ -1,0 +1,21 @@
+﻿# ODM Design Principles
+
+## Swiss Army Knife of ONVIF
+
+ODM's mission is to be the swiss army knife of ONVIF — it must work with non-compliant, broken, and partial ONVIF implementations on a best-effort basis. Never drop a camera because something in its ONVIF support doesn't follow the spec completely.
+
+ODM routinely encounters cameras with broken ONVIF support. Its value proposition is tolerance — attempt every fallback, accept partial implementations, never give up.
+
+### ONVIF Device Initialization — Escalating Fallback Chain
+
+When connecting to any camera, follow this sequence. Never stop at the first failure — always try the next level:
+
+1. **Parse Profile T scope** from WS-Discovery → early Media2 hint, but do not rely on it exclusively (non-compliant cameras may support Media2 without advertising Profile T)
+2. **`GetServices()`** → preferred source for all service xAddrs (spec-compliant path)
+3. **`GetCapabilities()`** → fallback if GetServices fails or returns incomplete data
+4. **Hardcoded URL construction** → last resort (e.g. append `/onvif/media_service` to device base URL) for cameras that implement neither
+5. **Try Media2 first** if any signal suggests it; fall back to Media1 on any failure
+6. **Never rewrite host:port** unless the advertised address is unroutable (loopback / any-address) — in that case substitute the known device IP but leave the port untouched
+7. **Per-call retry on raw xAddr** if the adjusted URL fails
+
+Do NOT remove fallbacks in the name of simplicity. Do NOT assume any single ONVIF call will succeed. Do NOT drop cameras that fail the spec.

--- a/odm/odm.tests/CameraCompatibilitySweepTests.cs
+++ b/odm/odm.tests/CameraCompatibilitySweepTests.cs
@@ -1,0 +1,415 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading;
+using Microsoft.FSharp.Control;
+using Microsoft.FSharp.Core;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using odm.core;
+using odm.ui.core;
+using onvif.services;
+
+namespace odm.tests
+{
+    /// <summary>
+    /// Camera compatibility sweep — mirrors the real ODM UI workflow:
+    ///   1. Read credentials.dat via CredentialStore (DPAPI-decrypted) and report count.
+    ///   2. Run ONVIF WS-Discovery for 5 s; report discovered cameras.
+    ///   3. For each camera try every stored credential (+ anonymous); report first that works.
+    ///   4. For each authenticated camera get the first profile's RTSP stream URI (no credential logging).
+    ///   5. For each stream URI spawn HostedPlayer headlessly for 5 s and report whether it played.
+    ///
+    /// Nothing is asserted — every step is allowed to fail.  The test is Inconclusive when
+    /// no cameras are discovered or no camera can be authenticated; otherwise it is always green.
+    /// The Markdown report captures per-camera outcomes.
+    ///
+    /// Step 5 uses a TCP socket probe to the RTSP port (default 554) instead of live playback.
+    ///
+    /// Optional: set ODM_SWEEP_REPORT_DIR to override where the report is written.
+    /// </summary>
+    [TestClass]
+    public class CameraCompatibilitySweepTests
+    {
+        // ----------------------------------------------------------------
+        // Per-step result
+        // ----------------------------------------------------------------
+
+        private class StepResult
+        {
+            public bool   Ok    { get; set; }
+            public string Value { get; set; }
+            public string Error { get; set; }
+
+            public static StepResult Pass(string value = null) =>
+                new StepResult { Ok = true, Value = value };
+            public static StepResult Fail(string error) =>
+                new StepResult { Ok = false, Error = Truncate(error, 120) };
+        }
+
+        private static string Truncate(string s, int max)
+        {
+            if (s == null) return string.Empty;
+            return s.Length <= max ? s : s.Substring(0, max) + "…";
+        }
+
+        // ----------------------------------------------------------------
+        // Per-camera result
+        // ----------------------------------------------------------------
+
+        private class CameraResult
+        {
+            public string     EndpointRef  { get; set; }
+            public Uri[]      Uris         { get; set; }
+            public StepResult Login        { get; set; }
+            public string     AuthUser     { get; set; }  // username that worked — no password logged
+            public StepResult Profiles     { get; set; }
+            public StepResult StreamUri    { get; set; }
+            public StepResult StreamPlay   { get; set; }
+        }
+
+        // ----------------------------------------------------------------
+        // WS-Discovery node collector
+        // ----------------------------------------------------------------
+
+        private class NodeCollector : IObserver<INvtNode>
+        {
+            public readonly List<INvtNode> Nodes = new List<INvtNode>();
+            public void OnNext(INvtNode value)  { lock (Nodes) Nodes.Add(value); }
+            public void OnError(Exception error) { }
+            public void OnCompleted()            { }
+        }
+
+        // ----------------------------------------------------------------
+        // Helpers
+        // ----------------------------------------------------------------
+
+        private static T Run<T>(FSharpAsync<T> async, int timeoutMs = 30000)
+        {
+            return FSharpAsync.RunSynchronously(
+                async,
+                FSharpOption<int>.Some(timeoutMs),
+                FSharpOption<CancellationToken>.None);
+        }
+
+        private static List<INvtNode> DiscoverCameras(TimeSpan duration)
+        {
+            var manager = new NvtManager();
+            var nvtMgr  = (INvtManager)manager;
+            var collector = new NodeCollector();
+
+            using (nvtMgr.Observe().Subscribe(collector))
+            using (nvtMgr.Discover(duration))
+            {
+                // Wait for the probe window to expire, plus a small buffer.
+                Thread.Sleep(duration + TimeSpan.FromSeconds(1));
+            }
+
+            return collector.Nodes;
+        }
+
+        // ----------------------------------------------------------------
+        // Per-camera smoke test
+        // ----------------------------------------------------------------
+
+        private static CameraResult TestCamera(INvtNode node, IList<Account> creds)
+        {
+            var result = new CameraResult
+            {
+                EndpointRef = node.identity.endpointReference,
+                Uris        = node.identity.uris
+            };
+
+            // Global TLS settings (idempotent — safe to call per-camera)
+            ServicePointManager.SecurityProtocol  = SecurityProtocolType.Tls12;
+            ServicePointManager.Expect100Continue = false;
+            ServicePointManager.ServerCertificateValidationCallback = (s, c, ch, e) => true;
+
+            // Step 3 — try each stored credential, then anonymous.
+            // GetProfiles is used as the auth probe because device-service calls
+            // (GetServices, GetCapabilities) are PRE_AUTH and succeed with any credential,
+            // so CreateSession alone cannot verify that a password is correct.
+            INvtSession session       = null;
+            string      authUser      = null;
+            Account?    authCred      = null;
+            Profile[]   cachedProfiles = null;
+
+            foreach (var cred in creds)
+            {
+                try
+                {
+                    var nc      = new NetworkCredential(cred.Name, cred.Password);
+                    var factory = new NvtSessionFactory(nc);
+                    var s       = Run(factory.CreateSession(node.identity.uris), 15000);
+                    // Probe with GetProfiles — first call that requires real WSSE auth.
+                    // If this throws (e.g. 400/401), credentials are wrong; try the next.
+                    cachedProfiles = Run(s.GetProfiles(), 15000);
+                    session  = s;
+                    authUser = string.IsNullOrEmpty(cred.Name) ? "<blank>" : cred.Name;
+                    authCred = cred;
+                    break;
+                }
+                catch { /* wrong credential or unreachable — try next */ }
+            }
+
+            if (session == null)
+            {
+                // Last resort: anonymous
+                try
+                {
+                    var nc      = new NetworkCredential(string.Empty, string.Empty);
+                    var factory = new NvtSessionFactory(nc);
+                    var s       = Run(factory.CreateSession(node.identity.uris), 15000);
+                    try { cachedProfiles = Run(s.GetProfiles(), 15000); } catch { /* anonymous may not have media access */ }
+                    session  = s;
+                    authUser = "<anonymous>";
+                    authCred = Account.Anonymous;
+                }
+                catch { /* fall through */ }
+            }
+
+            if (session == null)
+            {
+                result.Login      = StepResult.Fail("no credential worked");
+                result.Profiles   = StepResult.Fail("skipped — login failed");
+                result.StreamUri  = StepResult.Fail("skipped — login failed");
+                result.StreamPlay = StepResult.Fail("skipped — login failed");
+                return result;
+            }
+
+            result.Login    = StepResult.Pass();
+            result.AuthUser = authUser;
+
+            // Step 4a — GetProfiles (result already cached from credential probe above)
+            Profile[] profiles = null;
+            try
+            {
+                profiles         = cachedProfiles ?? Run(session.GetProfiles(), 15000);
+                result.Profiles  = StepResult.Pass(
+                    string.Format("{0} profile(s)", profiles == null ? 0 : profiles.Length));
+            }
+            catch (Exception ex)
+            {
+                result.Profiles = StepResult.Fail(ex.Message);
+            }
+
+            // Step 4b — GetStreamUri for first profile
+            string streamUriStr = null;
+            if (profiles != null && profiles.Length > 0)
+            {
+                try
+                {
+                    var setup = new StreamSetup
+                    {
+                        stream    = StreamType.rtpUnicast,
+                        transport = new Transport { protocol = TransportProtocol.rtsp }
+                    };
+                    var mediaUri    = Run(session.GetStreamUri(setup, profiles[0].token), 15000);
+                    streamUriStr    = mediaUri != null ? mediaUri.uri : null;
+                    result.StreamUri = streamUriStr != null
+                        ? StepResult.Pass(streamUriStr)
+                        : StepResult.Fail("null URI returned");
+                }
+                catch (Exception ex)
+                {
+                    result.StreamUri = StepResult.Fail(ex.Message);
+                }
+            }
+            else
+            {
+                result.StreamUri = StepResult.Fail("skipped — no profiles");
+            }
+
+            // Step 5 — TCP reachability probe to the RTSP port
+            if (!string.IsNullOrEmpty(streamUriStr) && result.StreamUri.Ok)
+            {
+                result.StreamPlay = TestRtspReachable(streamUriStr);
+            }
+            else
+            {
+                result.StreamPlay = StepResult.Fail("skipped — no stream URI");
+            }
+
+            return result;
+        }
+
+        private static StepResult TestRtspReachable(string streamUri)
+        {
+            try
+            {
+                var uri  = new Uri(streamUri);
+                int port = uri.IsDefaultPort ? 554 : uri.Port;
+                using (var client = new TcpClient())
+                {
+                    var ar = client.BeginConnect(uri.Host, port, null, null);
+                    if (!ar.AsyncWaitHandle.WaitOne(5000))
+                        return StepResult.Fail(string.Format("{0}:{1} TCP timeout", uri.Host, port));
+                    client.EndConnect(ar);
+                    return StepResult.Pass(string.Format("{0}:{1} reachable", uri.Host, port));
+                }
+            }
+            catch (Exception ex)
+            {
+                return StepResult.Fail("TCP probe: " + ex.Message);
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // Report generation
+        // ----------------------------------------------------------------
+
+        private static string BuildReport(List<CameraResult> results, int credCount)
+        {
+            var sb = new StringBuilder();
+            sb.AppendLine("# Camera Compatibility Sweep Report");
+            sb.AppendLine();
+            sb.AppendLine(string.Format("**Date:** {0:yyyy-MM-dd HH:mm:ss} UTC", System.DateTime.UtcNow));
+            sb.AppendLine(string.Format("**Stored credentials:** {0}", credCount));
+            sb.AppendLine(string.Format("**Cameras discovered:** {0}", results.Count));
+            sb.AppendLine();
+
+            sb.AppendLine("## Summary");
+            sb.AppendLine();
+            sb.AppendLine("| Camera endpoint | Auth user | Login | Profiles | StreamURI | RTSP TCP |");
+            sb.AppendLine("|----------------|:---------:|:-----:|:--------:|:---------:|:--------:|");
+
+            foreach (var r in results)
+            {
+                sb.AppendLine(string.Format("| {0} | {1} | {2} | {3} | {4} | {5} |",
+                    Truncate(r.EndpointRef, 50),
+                    r.AuthUser ?? "—",
+                    Flag(r.Login),
+                    Flag(r.Profiles),
+                    Flag(r.StreamUri),
+                    Flag(r.StreamPlay)));
+            }
+
+            sb.AppendLine();
+            sb.AppendLine("## Detail");
+            sb.AppendLine();
+
+            foreach (var r in results)
+            {
+                sb.AppendLine(string.Format("### {0}", r.EndpointRef));
+                sb.AppendLine();
+                if (r.Uris != null)
+                    foreach (var u in r.Uris)
+                        sb.AppendLine(string.Format("- endpoint URI: `{0}`", u));
+                sb.AppendLine();
+                AppendStep(sb, "Login",     r.Login,      r.AuthUser != null ? "user=" + r.AuthUser : null);
+                AppendStep(sb, "Profiles",  r.Profiles,   null);
+                AppendStep(sb, "StreamURI", r.StreamUri,  null);
+                AppendStep(sb, "RTSP TCP",  r.StreamPlay, null);
+                sb.AppendLine();
+            }
+
+            return sb.ToString();
+        }
+
+        private static string Flag(StepResult r)
+        {
+            if (r == null) return "—";
+            return r.Ok ? "✓" : "✗";
+        }
+
+        private static void AppendStep(StringBuilder sb, string name, StepResult r, string extra)
+        {
+            if (r == null) { sb.AppendLine(string.Format("- **{0}:** —", name)); return; }
+            if (r.Ok)
+            {
+                var detail = new List<string>();
+                if (!string.IsNullOrEmpty(r.Value)) detail.Add(r.Value);
+                if (!string.IsNullOrEmpty(extra))   detail.Add(extra);
+                sb.AppendLine(string.Format("- **{0}:** PASS{1}", name,
+                    detail.Count > 0 ? " — " + string.Join(", ", detail) : ""));
+            }
+            else
+            {
+                sb.AppendLine(string.Format("- **{0}:** FAIL — {1}", name, r.Error));
+            }
+        }
+
+        // ----------------------------------------------------------------
+        // The single test method
+        // ----------------------------------------------------------------
+
+        [TestMethod]
+        [TestCategory("Integration")]
+        [TestCategory("Sweep")]
+        public void Sweep_AllCameras_ProduceCompatibilityReport()
+        {
+            // Step 1 — load credentials from CredentialStore (DPAPI)
+            var creds = CredentialStore.Instance.GetAll();
+            Console.WriteLine("CredentialStore: {0} credential(s) loaded.", creds.Count);
+            if (creds.Count == 0)
+                Console.WriteLine("No stored credentials — anonymous login will be attempted per camera.");
+
+            // Step 2 — WS-Discovery
+            Console.WriteLine("Running WS-Discovery (5 s)…");
+            List<INvtNode> nodes;
+            try
+            {
+                nodes = DiscoverCameras(TimeSpan.FromSeconds(5));
+            }
+            catch (Exception ex)
+            {
+                Assert.Inconclusive("WS-Discovery failed: " + ex.Message);
+                return;
+            }
+            Console.WriteLine("Discovered {0} camera(s).", nodes.Count);
+
+            if (nodes.Count == 0)
+            {
+                Assert.Inconclusive(
+                    "No cameras found via WS-Discovery. Check that the test host is on the camera network.");
+                return;
+            }
+
+            // Steps 3–5 — per-camera sweep
+            var results = new List<CameraResult>();
+            foreach (var node in nodes)
+            {
+                Console.WriteLine("Testing: {0}", node.identity.endpointReference);
+                var r = TestCamera(node, creds);
+                results.Add(r);
+
+                Console.WriteLine("  Login={0} ({1})  Profiles={2}  StreamURI={3}  RTSP-TCP={4}",
+                    r.Login  != null && r.Login.Ok  ? "OK"  : "FAIL",
+                    r.AuthUser ?? "—",
+                    r.Profiles != null && r.Profiles.Ok  ? r.Profiles.Value : "FAIL",
+                    r.StreamUri != null && r.StreamUri.Ok ? r.StreamUri.Value : "FAIL",
+                    r.StreamPlay != null && r.StreamPlay.Ok ? r.StreamPlay.Value : "FAIL");
+            }
+
+            // Generate report
+            var report    = BuildReport(results, creds.Count);
+            var reportDir = Environment.GetEnvironmentVariable("ODM_SWEEP_REPORT_DIR")
+                         ?? AppDomain.CurrentDomain.BaseDirectory;
+            var reportPath = Path.Combine(reportDir,
+                string.Format("camera-sweep-{0:yyyyMMdd-HHmmss}.md", System.DateTime.UtcNow));
+            try   { File.WriteAllText(reportPath, report, Encoding.UTF8); }
+            catch { /* non-fatal */ }
+
+            Console.WriteLine();
+            Console.WriteLine("======== CAMERA SWEEP REPORT ========");
+            Console.WriteLine(report);
+            Console.WriteLine("Report written to: " + reportPath);
+
+            int loginCount = 0;
+            foreach (var r in results)
+                if (r.Login != null && r.Login.Ok) loginCount++;
+
+            Console.WriteLine("{0}/{1} cameras authenticated.", loginCount, results.Count);
+
+            // The test is always green — the report captures outcomes.
+            // Mark Inconclusive only when zero cameras could be authenticated, so CI
+            // can distinguish "all cameras healthy" from "nothing worked".
+            if (loginCount == 0)
+                Assert.Inconclusive(string.Format(
+                    "0/{0} cameras authenticated. Check stored credentials or network. Report: {1}",
+                    results.Count, reportPath));
+        }
+    }
+}

--- a/odm/odm.tests/odm.tests.csproj
+++ b/odm/odm.tests/odm.tests.csproj
@@ -58,6 +58,10 @@
       <HintPath>$(OdmViewsBin)utils.common.dll</HintPath>
       <Private>true</Private>
     </Reference>
+    <Reference Include="onvif.discovery">
+      <HintPath>$(OdmViewsBin)onvif.discovery.dll</HintPath>
+      <Private>true</Private>
+    </Reference>
     <Reference Include="System.Security" />
     <Reference Include="System.ServiceModel" />
   </ItemGroup>

--- a/odm/odm.tests/run-sweep.bat
+++ b/odm/odm.tests/run-sweep.bat
@@ -1,0 +1,44 @@
+@echo off
+setlocal
+
+:: Paths -- override from command line if needed
+::   run-sweep.bat [ODM_ROOT] [REPORT_DIR] [CRED_SRC]
+set ODM_ROOT=%~dp0..\..
+if not "%~1"=="" set ODM_ROOT=%~1
+
+set TEST_BIN=%ODM_ROOT%\odm\odm.tests\bin\x64\Release\net48
+set CRED_SRC=C:\Program Files\Synesis\Onvif Device Manager\config\credentials.dat
+if not "%~3"=="" set CRED_SRC=%~3
+
+set VSTEST="C:\Program Files\Microsoft Visual Studio\2022\Community\Common7\IDE\CommonExtensions\Microsoft\TestWindow\vstest.console.exe"
+
+if not "%~2"=="" set ODM_SWEEP_REPORT_DIR=%~2
+
+:: Ensure config dir exists
+if not exist "%TEST_BIN%\config\" mkdir "%TEST_BIN%\config"
+
+:: Always copy (overwrite) credentials.dat so the latest file is used every run
+echo Copying credentials.dat from "%CRED_SRC%"...
+copy /y "%CRED_SRC%" "%TEST_BIN%\config"
+if errorlevel 1 (
+    echo ERROR: Could not copy credentials.dat.
+    echo   - Source: "%CRED_SRC%"
+    echo   - Pass a custom path as third arg: run-sweep.bat "" "" "C:\path\to\credentials.dat"
+    pause
+    exit /b 1
+)
+
+echo Running camera compatibility sweep...
+echo.
+
+%VSTEST% "%TEST_BIN%\odm.tests.dll" /TestCaseFilter:"TestCategory=Sweep" /Platform:x64
+
+echo.
+:: Print the full path of the generated report
+for /f "delims=" %%F in ('dir /b /od "%TEST_BIN%\camera-sweep-*.md" 2^>nul') do set LAST_REPORT=%%F
+if defined LAST_REPORT (
+    echo Report: %TEST_BIN%\%LAST_REPORT%
+) else (
+    echo No report file found in %TEST_BIN%
+)
+pause

--- a/odm/odm.ui.views/AppDefaults.cs
+++ b/odm/odm.ui.views/AppDefaults.cs
@@ -57,9 +57,7 @@ namespace odm.ui {
 		}
 		static public string ConfigFolderPath {
 			get {
-				string path = Path.Combine(
-					Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
-					@"Synesis\Onvif Device Manager\config\");
+				string path = AppDataPath + @"config\";
 				if (!Directory.Exists(path))
 					Directory.CreateDirectory(path);
 				return path;

--- a/odm/odm.ui.views/AppDefaults.cs
+++ b/odm/odm.ui.views/AppDefaults.cs
@@ -57,7 +57,9 @@ namespace odm.ui {
 		}
 		static public string ConfigFolderPath {
 			get {
-				string path = AppDataPath + @"config\";
+				string path = Path.Combine(
+					Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles),
+					@"Synesis\Onvif Device Manager\config\");
 				if (!Directory.Exists(path))
 					Directory.CreateDirectory(path);
 				return path;

--- a/onvif/onvif.session/NvtSession.fs
+++ b/onvif/onvif.session/NvtSession.fs
@@ -87,6 +87,22 @@ namespace odm.core
         abstract GetAllCapabilities: unit -> Async<Capabilities>
         abstract GetVideoEncoderConfigurationsMedia2: unit -> Async<VideoEncoderConfiguration[]>
     end
+
+    type private ServiceEndpointMap = {
+        Media1XAddr: string option
+        Media2XAddr: string option
+        PtzXAddr: string option
+        ImagingXAddr: string option
+        EventsXAddr: string option
+        AnalyticsXAddr: string option
+        ReceiverXAddr: string option
+        AnalyticsDeviceXAddr: string option
+        RecordingXAddr: string option
+        ReplayXAddr: string option
+        ActionEngineXAddr: string option
+    }
+    with
+        member this.HasMedia2 = this.Media2XAddr.IsSome
     
     type SecurityUserNameToken(userName:string, password:string, deviceTime:System.DateTime) = class
         let delta = 
@@ -750,12 +766,88 @@ namespace odm.core
                 })
                 fun()->comp
 
-            let GetServices = 
+            let GetServices =
                 let comp = Async.Memoize(async{
                     let! dev = GetDeviceClient()
                     return! dev.GetServices(false)
                 })
                 fun()->comp
+
+            // Resolves all service xAddrs at session creation time using a three-level fallback:
+            // 1. GetServices() namespace match, 2. GetCapabilities() field, 3. Constructed default URL.
+            // Started eagerly in the background so service clients find results already cached.
+            let GetResolvedEndpoints =
+                let comp = Async.Memoize(async{
+                    let! servicesOpt = async{
+                        try
+                            let! svcs = GetServices()
+                            return if svcs |> IsNull then None else Some svcs
+                        with _ -> return None
+                    }
+                    let! capsOpt = async{
+                        try
+                            let! caps = GetCapabilities()
+                            return if caps |> IsNull then None else Some caps
+                        with _ -> return None
+                    }
+                    let findServiceXAddr ns =
+                        servicesOpt |> Option.bind (fun svcs ->
+                            svcs |> Seq.tryFind (fun (s:Service) -> s.Namespace = ns)
+                            |> Option.bind (fun s ->
+                                if String.IsNullOrEmpty(s.XAddr) then None else Some s.XAddr
+                            )
+                        )
+                    let getCapsXAddr (f: Capabilities -> string) =
+                        capsOpt |> Option.bind (fun caps ->
+                            try
+                                let xAddr = f caps
+                                if String.IsNullOrEmpty(xAddr) then None else Some xAddr
+                            with _ -> None
+                        )
+                    let constructUrl path =
+                        let b = new UriBuilder(deviceUri)
+                        b.Path <- path
+                        b.Query <- ""
+                        Some (b.Uri.ToString())
+                    let resolve ns capsGetter defaultPath =
+                        match findServiceXAddr ns with
+                        | Some x -> Some x
+                        | None ->
+                            match getCapsXAddr capsGetter with
+                            | Some x -> Some x
+                            | None -> constructUrl defaultPath
+                    let resolveNoLastResort ns capsGetter =
+                        match findServiceXAddr ns with
+                        | Some x -> Some x
+                        | None -> getCapsXAddr capsGetter
+                    return {
+                        Media1XAddr = resolve "http://www.onvif.org/ver10/media/wsdl"
+                                        (fun c -> c.media.xAddr)
+                                        "/onvif/media_service"
+                        Media2XAddr = findServiceXAddr "http://www.onvif.org/ver20/media/wsdl"
+                        PtzXAddr = resolve "http://www.onvif.org/ver20/ptz/wsdl"
+                                     (fun c -> c.ptz.xAddr)
+                                     "/onvif/ptz_service"
+                        ImagingXAddr = resolve "http://www.onvif.org/ver10/imaging/wsdl"
+                                         (fun c -> c.imaging.xAddr)
+                                         "/onvif/imaging_service"
+                        EventsXAddr = resolve "http://www.onvif.org/ver10/events/wsdl"
+                                        (fun c -> c.events.xAddr)
+                                        "/onvif/events_service"
+                        AnalyticsXAddr = resolveNoLastResort "http://www.onvif.org/ver20/analytics/wsdl"
+                                           (fun c -> c.analytics.xAddr)
+                        ReceiverXAddr = resolveNoLastResort "http://www.onvif.org/ver10/receiver/wsdl"
+                                          (fun c -> c.extension.receiver.xAddr)
+                        AnalyticsDeviceXAddr = resolveNoLastResort "http://www.onvif.org/ver20/analyticsdevice/wsdl"
+                                                 (fun c -> c.extension.analyticsDevice.xAddr)
+                        RecordingXAddr = resolveNoLastResort "http://www.onvif.org/ver10/recording/wsdl"
+                                           (fun c -> c.extension.recording.xAddr)
+                        ReplayXAddr = resolveNoLastResort "http://www.onvif.org/ver10/replay/wsdl"
+                                        (fun c -> c.extension.replay.xAddr)
+                        ActionEngineXAddr = findServiceXAddr "http://www.onvif.org/ver10/actionengine/wsdl"
+                    }
+                })
+                fun() -> comp
 
 
             let GetDeviceInformation = 
@@ -779,45 +871,33 @@ namespace odm.core
                 else
                     url
 
+            // Returns true for addresses that are loopback/unroutable and must be replaced with
+            // the device's reachable host. Never touch the port — only substitute the host.
+            let isUnroutableHost (host: string) =
+                String.IsNullOrEmpty(host) ||
+                host = "127.0.0.1" ||
+                host = "0.0.0.0" ||
+                host = "::1" ||
+                String.Compare(host, "localhost", StringComparison.OrdinalIgnoreCase) = 0
+
             let FixUrl(url:Uri) = async{
-                let! resolved =
-                    async{
-                        if not(url.IsAbsoluteUri) then
-                            //return new Uri(deviceUri.GetBaseUri(), url)
-                            return new Uri(deviceUri, url)
-                        elif not(deviceUri.Host = url.Host) then
-                            if url.HostNameType = UriHostNameType.IPv4 then
-                                let! caps = GetCapabilities()
-                                let internalDeviceUrl = new Uri(caps.device.xAddr)
-                                if internalDeviceUrl.Host = url.Host then
-                                    if internalDeviceUrl.Port = url.Port && internalDeviceUrl.Scheme = url.Scheme then
-                                        return url.Relocate(deviceUri.Host, deviceUri.Port)
-                                    else
-                                        return url.Relocate(deviceUri.Host)
-//                            let baseUrl =
-//                                if url.Port < 0 then
-//                                    new Uri(sprintf "%s://%s" (url.Scheme) (deviceUri.Host))
-//                                else
-//                                    new Uri(sprintf "%s://%s:%d" (url.Scheme) (deviceUri.Host) (url.Port))
-//                            return new Uri(baseUrl, url.PathAndQuery)
-                                else
-                                    return url
-                            else
-                                return url
-                        else
-                            return url
-                    }
+                let resolved =
+                    if not(url.IsAbsoluteUri) then
+                        new Uri(deviceUri, url)
+                    elif isUnroutableHost url.Host then
+                        url.Relocate(deviceUri.Host)
+                    else
+                        url
                 return UpgradeSchemeIfNeeded resolved
             }
 
-            let GetMediaClient = 
+            let GetMediaClient =
                 let comp = Async.Memoize(async{
-                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetMediaClient") 
-                    let! caps = GetCapabilities()
-                    let xaddr = caps |> IfNotNull(fun x->x.media |> IfNotNull(fun x->x.xAddr))
-                    if IsNull(xaddr) then
-                        return null
-                    else
+                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetMediaClient")
+                    let! eps = GetResolvedEndpoints()
+                    match eps.Media1XAddr with
+                    | None -> return null
+                    | Some xaddr ->
                         do! Async.SwitchToThreadPool()
                         let! url = FixUrl(new Uri(xaddr, UriKind.RelativeOrAbsolute))
                         let useTls = url.Scheme = Uri.UriSchemeHttps
@@ -829,15 +909,13 @@ namespace odm.core
                 })
                 fun()->comp
 
-            let GetImagingClient = 
+            let GetImagingClient =
                 let comp = Async.Memoize(async{
-                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetImagingClient") 
-                    do! Async.SwitchToThreadPool()
-                    let! caps = GetCapabilities()
-                    let xaddr = caps |> IfNotNull(fun x->x.imaging |> IfNotNull(fun x->x.xAddr))
-                    if IsNull(xaddr) then
-                        return null
-                    else
+                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetImagingClient")
+                    let! eps = GetResolvedEndpoints()
+                    match eps.ImagingXAddr with
+                    | None -> return null
+                    | Some xaddr ->
                         do! Async.SwitchToThreadPool()
                         let! url = FixUrl(new Uri(xaddr, UriKind.RelativeOrAbsolute))
                         let useTls = url.Scheme = Uri.UriSchemeHttps
@@ -849,14 +927,13 @@ namespace odm.core
                 })
                 fun()->comp
 
-            let GetPtzClient = 
+            let GetPtzClient =
                 let comp = Async.Memoize(async{
-                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetPtzClient") 
-                    let! caps = GetCapabilities()
-                    let xaddr = caps |> IfNotNull(fun x->x.ptz |> IfNotNull(fun x->x.xAddr))
-                    if IsNull(xaddr) then
-                        return null
-                    else
+                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetPtzClient")
+                    let! eps = GetResolvedEndpoints()
+                    match eps.PtzXAddr with
+                    | None -> return null
+                    | Some xaddr ->
                         do! Async.SwitchToThreadPool()
                         let! url = FixUrl(new Uri(xaddr, UriKind.RelativeOrAbsolute))
                         let useTls = url.Scheme = Uri.UriSchemeHttps
@@ -868,14 +945,13 @@ namespace odm.core
                 })
                 fun()->comp
         
-            let GetEventClient = 
+            let GetEventClient =
                 let comp = Async.Memoize(async{
-                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetEventClient") 
-                    let! caps = GetCapabilities()
-                    let xaddr = caps |> IfNotNull(fun x->x.events |> IfNotNull(fun x->x.xAddr))
-                    if IsNull(xaddr) then
-                        return null
-                    else
+                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetEventClient")
+                    let! eps = GetResolvedEndpoints()
+                    match eps.EventsXAddr with
+                    | None -> return null
+                    | Some xaddr ->
                         do! Async.SwitchToThreadPool()
                         let! url = FixUrl(new Uri(xaddr, UriKind.RelativeOrAbsolute))
                         let useTls = url.Scheme = Uri.UriSchemeHttps
@@ -887,14 +963,13 @@ namespace odm.core
                 })
                 fun()->comp
 
-            let GetAnalyticsClient = 
+            let GetAnalyticsClient =
                 let comp = Async.Memoize(async{
-                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetAnalyticsClient") 
-                    let! caps = GetCapabilities()
-                    let xaddr = caps |> IfNotNull(fun x->x.analytics |> IfNotNull(fun x->x.xAddr))
-                    if IsNull(xaddr) then
-                        return null
-                    else
+                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetAnalyticsClient")
+                    let! eps = GetResolvedEndpoints()
+                    match eps.AnalyticsXAddr with
+                    | None -> return null
+                    | Some xaddr ->
                         do! Async.SwitchToThreadPool()
                         let! url = FixUrl(new Uri(xaddr, UriKind.RelativeOrAbsolute))
                         let useTls = url.Scheme = Uri.UriSchemeHttps
@@ -906,14 +981,13 @@ namespace odm.core
                 })
                 fun()->comp
             
-            let GetReceiverClient = 
+            let GetReceiverClient =
                 let comp = Async.Memoize(async{
-                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetReceiverClient") 
-                    let! caps = GetCapabilities()
-                    let xaddr = caps |> IfNotNull(fun x->x.extension |> IfNotNull(fun x->x.receiver|> IfNotNull(fun x->x.xAddr)))
-                    if IsNull(xaddr) then
-                        return null
-                    else
+                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetReceiverClient")
+                    let! eps = GetResolvedEndpoints()
+                    match eps.ReceiverXAddr with
+                    | None -> return null
+                    | Some xaddr ->
                         do! Async.SwitchToThreadPool()
                         let! url = FixUrl(new Uri(xaddr, UriKind.RelativeOrAbsolute))
                         let useTls = url.Scheme = Uri.UriSchemeHttps
@@ -925,14 +999,13 @@ namespace odm.core
                 })
                 fun()->comp
             
-            let GetAnalyticsDeviceClient = 
+            let GetAnalyticsDeviceClient =
                 let comp = Async.Memoize(async{
-                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetAnalyticsDeviceClient") 
-                    let! caps = GetCapabilities()
-                    let xaddr = caps |> IfNotNull(fun x->x.extension |> IfNotNull(fun x->x.analyticsDevice|> IfNotNull(fun x->x.xAddr)))
-                    if IsNull(xaddr) then
-                        return null
-                    else
+                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetAnalyticsDeviceClient")
+                    let! eps = GetResolvedEndpoints()
+                    match eps.AnalyticsDeviceXAddr with
+                    | None -> return null
+                    | Some xaddr ->
                         do! Async.SwitchToThreadPool()
                         let! url = FixUrl(new Uri(xaddr, UriKind.RelativeOrAbsolute))
                         let useTls = url.Scheme = Uri.UriSchemeHttps
@@ -944,14 +1017,13 @@ namespace odm.core
                 })
                 fun()->comp
 
-            let GetRecordingsClient = 
+            let GetRecordingsClient =
                 let comp = Async.Memoize(async{
-                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetRecordingsClient") 
-                    let! caps = GetCapabilities()
-                    let xaddr = caps |> IfNotNull(fun x->x.extension |> IfNotNull(fun x->x.recording|> IfNotNull(fun x->x.xAddr)))
-                    if IsNull(xaddr) then
-                        return null
-                    else
+                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetRecordingsClient")
+                    let! eps = GetResolvedEndpoints()
+                    match eps.RecordingXAddr with
+                    | None -> return null
+                    | Some xaddr ->
                         do! Async.SwitchToThreadPool()
                         let! url = FixUrl(new Uri(xaddr, UriKind.RelativeOrAbsolute))
                         let useTls = url.Scheme = Uri.UriSchemeHttps
@@ -968,13 +1040,12 @@ namespace odm.core
                     dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetActionEngineClient")
                     let! caps = GetCapabilities()
                     if caps.device.system.supportedVersions |> Seq.exists (fun v -> v >= OnvifVersion.v2_1) then
-                        let! services = GetServices()
-                        let service = services.FirstOrDefault (fun (s:Service) -> s.Namespace = "http://www.onvif.org/ver10/actionengine/wsdl") 
-                        if service |> IsNull  then
-                            return null
-                        else 
+                        let! eps = GetResolvedEndpoints()
+                        match eps.ActionEngineXAddr with
+                        | None -> return null
+                        | Some xaddr ->
                             do! Async.SwitchToThreadPool()
-                            let! url = FixUrl(new Uri(service.XAddr, UriKind.RelativeOrAbsolute))
+                            let! url = FixUrl(new Uri(xaddr, UriKind.RelativeOrAbsolute))
                             let useTls = url.Scheme = Uri.UriSchemeHttps
                             let! factory = getActionEngineFactory(useTls)
                             let endpointAddr = new EndpointAddress(url)
@@ -988,12 +1059,11 @@ namespace odm.core
 
             let GetReplayClient : unit -> Async<IReplayAsync> =
                 let comp = Async.Memoize(async{
-                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetReplayClient") 
-                    let! caps = GetCapabilities()
-                    let xaddr = caps |> IfNotNull(fun x->x.extension |> IfNotNull(fun x->x.replay|> IfNotNull(fun x->x.xAddr)))
-                    if IsNull(xaddr) then
-                        return null
-                    else
+                    dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetReplayClient")
+                    let! eps = GetResolvedEndpoints()
+                    match eps.ReplayXAddr with
+                    | None -> return null
+                    | Some xaddr ->
                         do! Async.SwitchToThreadPool()
                         let! url = FixUrl(new Uri(xaddr, UriKind.RelativeOrAbsolute))
                         let useTls = url.Scheme = Uri.UriSchemeHttps
@@ -1031,20 +1101,20 @@ namespace odm.core
                 fun() -> comp
 
             // Client for the ONVIF Media2 service (ver20/media/wsdl).
-            // Discovered via GetServices(); returns null if the camera does not advertise Media2.
+            // Media2 support is determined at session init via GetResolvedEndpoints(); returns null
+            // if the camera does not advertise Media2 in GetServices().
             let GetMedia2Client =
                 let comp = Async.Memoize(async{
                     dbg.Info(sprintf "%08X::%s" (sessionId.GetHashCode()) "GetMedia2Client")
-                    let! services = GetServices()
-                    if services |> IsNull then
+                    let! eps = GetResolvedEndpoints()
+                    if not eps.HasMedia2 then
                         return null
                     else
-                        let service = services.FirstOrDefault(fun (s:Service) -> s.Namespace = "http://www.onvif.org/ver20/media/wsdl")
-                        if service |> IsNull then
-                            return null
-                        else
+                        match eps.Media2XAddr with
+                        | None -> return null
+                        | Some xaddr ->
                             do! Async.SwitchToThreadPool()
-                            let! url = FixUrl(new Uri(service.XAddr, UriKind.RelativeOrAbsolute))
+                            let! url = FixUrl(new Uri(xaddr, UriKind.RelativeOrAbsolute))
                             let useTls = url.Scheme = Uri.UriSchemeHttps
                             let! factory = getMedia2Factory(useTls)
                             let endpointAddr = new EndpointAddress(url)
@@ -1117,6 +1187,9 @@ namespace odm.core
                             return raise err
                 }
                 fun() -> comp
+
+            // Kick off endpoint resolution eagerly so service clients find results already cached
+            do GetResolvedEndpoints() |> Async.Ignore |> Async.Start
 
             {
                 new INvtSession with


### PR DESCRIPTION
## Summary

- Spec-compliant session init with eager endpoint resolution and safe `FixUrl`
- Sweep test credential probe uses `GetProfiles` to properly verify auth (not just session creation)
- Fixed `CRED_SRC` path in `run-sweep.bat`

## Changes

- `c8ae9e4` refactor: spec-compliant session init with eager endpoint resolution and safe FixUrl
- `8df6234` fix: remove leading spaces from CRED_SRC in run-sweep.bat
- `279e7b7` fix: sweep test credential probe — use GetProfiles to verify auth

## Test plan

- [ ] Build Release x64 — succeeds ✅
- [ ] Launch ODM, discover cameras, verify session connects correctly
- [ ] Run sweep test, confirm credential probe works

🤖 Generated with [Claude Code](https://claude.com/claude-code)